### PR TITLE
refactor: Display meal queue in RecyclerView instead of TextView

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,12 +29,11 @@ android {
 }
 
 dependencies {
-
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
     implementation 'com.android.volley:volley:1.2.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/Meal.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/Meal.java
@@ -2,9 +2,7 @@ package com.jackingaming.mealmaker3000pos.models;
 
 import android.util.Log;
 
-import com.jackingaming.mealmaker3000pos.models.menuitems.Bread;
 import com.jackingaming.mealmaker3000pos.models.menuitems.MenuItem;
-import com.jackingaming.mealmaker3000pos.models.menuitems.Water;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -30,7 +28,6 @@ public class Meal {
 
         try {
             id = json.optLong(JSON_ID);
-            Log.i(TAG, "Meal(JSONObject) constructor id: " + id);
 
             JSONArray menuItemsAsJSONArray = (JSONArray) json.get(JSON_MENU_ITEMS);
             Log.i(TAG, "Meal(JSONObject) constructor menuItemsAsJSONArray: " + menuItemsAsJSONArray);

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/RecordOfMeal.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/RecordOfMeal.java
@@ -1,0 +1,107 @@
+package com.jackingaming.mealmaker3000pos.models;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class RecordOfMeal {
+    public static final String JSON_KEY = "key";
+    public static final String JSON_VALUE = "value";
+    public static final String JSON_TIMESTAMP = "timestamp";
+    public static final String JSON_TOPIC = "topic";
+    public static final String JSON_PARTITION = "partition";
+    public static final String JSON_OFFSET = "offset";
+
+    private long key;
+    private String value;
+    private long timestamp;
+    private String topic;
+    private int partition;
+    private long offset;
+
+    public RecordOfMeal(long key, String value, long timestamp, String topic, int partition, long offset) {
+        this.key = key;
+        this.value = value;
+        this.timestamp = timestamp;
+        this.topic = topic;
+        this.partition = partition;
+        this.offset = offset;
+    }
+
+    public RecordOfMeal(JSONObject recordOfMealAsJSON) {
+        try {
+            key = recordOfMealAsJSON.getLong(JSON_KEY);
+            value = recordOfMealAsJSON.getString(JSON_VALUE);
+            timestamp = recordOfMealAsJSON.getLong(JSON_TIMESTAMP);
+            topic = recordOfMealAsJSON.getString(JSON_TOPIC);
+            partition = recordOfMealAsJSON.getInt(JSON_PARTITION);
+            offset = recordOfMealAsJSON.getLong(JSON_OFFSET);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public JSONObject toJSON() {
+        JSONObject recordOfMealAsJSON = new JSONObject();
+
+        try {
+            recordOfMealAsJSON.put(JSON_KEY, key);
+            recordOfMealAsJSON.put(JSON_VALUE, value);
+            recordOfMealAsJSON.put(JSON_TIMESTAMP, timestamp);
+            recordOfMealAsJSON.put(JSON_TOPIC, topic);
+            recordOfMealAsJSON.put(JSON_PARTITION, partition);
+            recordOfMealAsJSON.put(JSON_OFFSET, offset);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        return recordOfMealAsJSON;
+    }
+
+    public long getKey() {
+        return key;
+    }
+
+    public void setKey(long key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public int getPartition() {
+        return partition;
+    }
+
+    public void setPartition(int partition) {
+        this.partition = partition;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    public void setOffset(long offset) {
+        this.offset = offset;
+    }
+}

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/recyclerview/RecordOfMealAdapter.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/recyclerview/RecordOfMealAdapter.java
@@ -1,0 +1,93 @@
+package com.jackingaming.mealmaker3000pos.recyclerview;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.jackingaming.mealmaker3000pos.R;
+import com.jackingaming.mealmaker3000pos.models.RecordOfMeal;
+
+import java.util.List;
+
+// Create the basic adapter extending from RecyclerView.Adapter
+// Note that we specify the custom ViewHolder which gives us access to our views
+public class RecordOfMealAdapter extends
+        RecyclerView.Adapter<RecordOfMealAdapter.ViewHolder> {
+
+    // Provide a direct reference to each of the views within a data item
+    // Used to cache the views within the item layout for fast access
+    public class ViewHolder extends RecyclerView.ViewHolder {
+        // Your holder should contain a member variable
+        // for any view that will be set as you render a row
+        public TextView keyTextView;
+        public TextView valueTextView;
+        public TextView timestampTextView;
+        public TextView topicTextView;
+        public TextView offsetTextView;
+        public TextView partitionTextView;
+
+        // We also create a constructor that accepts the entire item row
+        // and does the view lookups to find each subview
+        public ViewHolder(View itemView) {
+            // Stores the itemView in a public final member variable that can be used
+            // to access the context from any ViewHolder instance.
+            super(itemView);
+
+            keyTextView = (TextView) itemView.findViewById(R.id.tv_key);
+            valueTextView = (TextView) itemView.findViewById(R.id.tv_value);
+            timestampTextView = (TextView) itemView.findViewById(R.id.tv_timestamp);
+            topicTextView = (TextView) itemView.findViewById(R.id.tv_topic);
+            offsetTextView = (TextView) itemView.findViewById(R.id.tv_offset);
+            partitionTextView = (TextView) itemView.findViewById(R.id.tv_partition);
+        }
+    }
+
+    // Store a member variable for the records of meal
+    private List<RecordOfMeal> recordsOfMeal;
+
+    // Pass in the records of meal list into the constructor
+    public RecordOfMealAdapter(List<RecordOfMeal> recordsOfMeal) {
+        this.recordsOfMeal = recordsOfMeal;
+    }
+
+    // Usually involves inflating a layout from XML and returning the holder
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        Context context = parent.getContext();
+        LayoutInflater inflater = LayoutInflater.from(context);
+
+        // Inflate the custom layout
+        View recordOfMealView = inflater.inflate(R.layout.item_recordofmeal, parent, false);
+
+        // Return a new holder instance
+        ViewHolder viewHolder = new ViewHolder(recordOfMealView);
+        return viewHolder;
+    }
+
+    // Involves populating data into the item through holder
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        // Get the data model based on position
+        RecordOfMeal recordOfMeal = recordsOfMeal.get(position);
+
+        // Set item views based on your views and data model
+        holder.keyTextView.setText("KEY: " + Long.toString(recordOfMeal.getKey()));
+        holder.valueTextView.setText("VALUE: " + recordOfMeal.getValue());
+        holder.timestampTextView.setText("TIMESTAMP: " + Long.toString(recordOfMeal.getTimestamp()));
+        holder.topicTextView.setText("TOPIC: " + recordOfMeal.getTopic());
+        holder.offsetTextView.setText("OFFSET: " + Long.toString(recordOfMeal.getOffset()));
+        holder.partitionTextView.setText("PARTITION: " + Integer.toString(recordOfMeal.getPartition()));
+    }
+
+    // Returns the total count of items in the list
+    @Override
+    public int getItemCount() {
+        return recordsOfMeal.size();
+    }
+}

--- a/app/src/main/res/layout/action_view_custom.xml
+++ b/app/src/main/res/layout/action_view_custom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/ivCustomAction"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_menu_delete" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/action_view_progressbar.xml
+++ b/app/src/main/res/layout/action_view_progressbar.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProgressBar xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/pbMenuItemAction"
+    style="?android:attr/progressBarStyleLarge"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+</ProgressBar>

--- a/app/src/main/res/layout/activity_meal_queue_viewer.xml
+++ b/app/src/main/res/layout/activity_meal_queue_viewer.xml
@@ -6,8 +6,8 @@
     android:layout_height="match_parent"
     tools:context=".MealQueueViewerActivity">
 
-    <TextView
-        android:id="@+id/textView_meal_queue_viewer"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_meal_queue_viewer"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@id/button_refresh"
@@ -23,6 +23,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/textView_meal_queue_viewer" />
+        app:layout_constraintTop_toBottomOf="@id/rv_meal_queue_viewer" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_recordofmeal.xml
+++ b/app/src/main/res/layout/item_recordofmeal.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/tv_key"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/tv_value"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toLeftOf="@id/tv_timestamp"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_value"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toLeftOf="@id/tv_topic"
+        app:layout_constraintTop_toBottomOf="@id/tv_key" />
+
+    <TextView
+        android:id="@+id/tv_timestamp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/tv_topic"
+        app:layout_constraintLeft_toRightOf="@id/tv_key"
+        app:layout_constraintRight_toLeftOf="@id/tv_offset"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_topic"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toRightOf="@id/tv_value"
+        app:layout_constraintRight_toLeftOf="@id/tv_partition"
+        app:layout_constraintTop_toBottomOf="@id/tv_timestamp" />
+
+    <TextView
+        android:id="@+id/tv_offset"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/tv_partition"
+        app:layout_constraintLeft_toRightOf="@id/tv_timestamp"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_partition"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toRightOf="@id/tv_topic"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_offset" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/options_menu_meal_queue_viewer_activity.xml
+++ b/app/src/main/res/menu/options_menu_meal_queue_viewer_activity.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_item_actionview_custom"
+        android:icon="@drawable/ic_menu_camera"
+        android:orderInCategory="1"
+        android:title="custom"
+        android:visible="false"
+        app:actionLayout="@layout/action_view_custom"
+        app:showAsAction="always|collapseActionView" />
+    <item
+        android:id="@+id/menu_item_refresh"
+        android:icon="@drawable/perm_group_sync_settings"
+        android:orderInCategory="50"
+        android:title="refresh"
+        app:showAsAction="always" />
+    <item
+        android:id="@+id/menu_item_actionview_progressbar"
+        android:orderInCategory="100"
+        android:title="progressbar"
+        android:visible="false"
+        app:actionLayout="@layout/action_view_progressbar"
+        app:showAsAction="always" />
+</menu>


### PR DESCRIPTION
Removed refresh button that was taking up screen space beneath the RecyclerView. Replaced the refresh button with a refresh ActionView in the options menu. This causes a indeterminate ProgressBar to become visible. Its visibility is hidden when we get a response from the server. Moving the control/visual-indicator to the options menu (action bar) allows for more screen space for the RecyclerView and the user is informed of the on-going network request without obscuring the main part of the screen.