### PR TITLE
fix: Customization subclasses' constructor with JSONObject parameter

### DIFF
--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/AddInCustomization.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/AddInCustomization.java
@@ -1,5 +1,7 @@
 package com.jackingaming.mealmaker3000pos.models.menuitems.drinks.customizations;
 
+import android.util.Log;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -22,8 +24,24 @@ public class AddInCustomization extends Customization {
 
     public AddInCustomization(JSONObject addInCustomizationAsJSON) throws JSONException {
         super(addInCustomizationAsJSON);
-        lineTheCup = (LineTheCup) addInCustomizationAsJSON.get(JSON_LINE_THE_CUP);
-        powder = (Powder) addInCustomizationAsJSON.get(JSON_POWDER);
+
+        String lineTheCupAsString = addInCustomizationAsJSON.get(JSON_LINE_THE_CUP).toString();
+        for (int i = 0; i < LineTheCup.values().length; i++) {
+            if (LineTheCup.values()[i].toString().equals(lineTheCupAsString)) {
+                Log.i("AddInCustomization", "AddInCustomization(JSONObject) LineTheCup." + LineTheCup.values()[i].toString());
+                lineTheCup = LineTheCup.values()[i];
+                break;
+            }
+        }
+
+        String powderAsString = addInCustomizationAsJSON.get(JSON_POWDER).toString();
+        for (int i = 0; i < Powder.values().length; i++) {
+            if (Powder.values()[i].toString().equals(powderAsString)) {
+                Log.i("AddInCustomization", "AddInCustomization(JSONObject) Powder." + Powder.values()[i].toString());
+                powder = Powder.values()[i];
+                break;
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/CupOptionCustomization.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/CupOptionCustomization.java
@@ -1,5 +1,7 @@
 package com.jackingaming.mealmaker3000pos.models.menuitems.drinks.customizations;
 
+import android.util.Log;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -18,7 +20,15 @@ public class CupOptionCustomization extends Customization {
 
     public CupOptionCustomization(JSONObject cupOptionCustomizationAsJSON) throws JSONException {
         super(cupOptionCustomizationAsJSON);
-        cupSize = (CupSize) cupOptionCustomizationAsJSON.get(JSON_CUP_SIZE);
+
+        String cupSizeAsString = cupOptionCustomizationAsJSON.get(JSON_CUP_SIZE).toString();
+        for (int i = 0; i < CupSize.values().length; i++) {
+            if (CupSize.values()[i].toString().equals(cupSizeAsString)) {
+                Log.i("CupOptionCustomization", "CupOptionCustomization(JSONObject) CupSize." + CupSize.values()[i].toString());
+                cupSize = CupSize.values()[i];
+                break;
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/EspressoShotCustomization.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/EspressoShotCustomization.java
@@ -1,5 +1,8 @@
 package com.jackingaming.mealmaker3000pos.models.menuitems.drinks.customizations;
 
+import android.annotation.SuppressLint;
+import android.util.Log;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -28,12 +31,45 @@ public class EspressoShotCustomization extends Customization {
         this.prep = builder.prep;
     }
 
+    @SuppressLint("LongLogTag")
     public EspressoShotCustomization(JSONObject espressoShotCustomizationAsJSON) throws JSONException {
         super(espressoShotCustomizationAsJSON);
-        roast = (Roast) espressoShotCustomizationAsJSON.get(JSON_ROAST);
-        quantity = (Quantity) espressoShotCustomizationAsJSON.get(JSON_QUANTITY);
-        type = (Type) espressoShotCustomizationAsJSON.get(JSON_TYPE);
-        prep = (Prep) espressoShotCustomizationAsJSON.get(JSON_PREP);
+
+        String roastAsString = espressoShotCustomizationAsJSON.get(JSON_ROAST).toString();
+        for (int i = 0; i < Roast.values().length; i++) {
+            if (Roast.values()[i].toString().equals(roastAsString)) {
+                Log.i("EspressoShotCustomization", "EspressoShotCustomization(JSONObject) Roast." + Roast.values()[i].toString());
+                roast = Roast.values()[i];
+                break;
+            }
+        }
+
+        String quantityAsString = espressoShotCustomizationAsJSON.get(JSON_QUANTITY).toString();
+        for (int i = 0; i < Quantity.values().length; i++) {
+            if (Quantity.values()[i].toString().equals(quantityAsString)) {
+                Log.i("EspressoShotCustomization", "EspressoShotCustomization(JSONObject) Quantity." + Quantity.values()[i].toString());
+                quantity = Quantity.values()[i];
+                break;
+            }
+        }
+
+        String typeAsString = espressoShotCustomizationAsJSON.get(JSON_TYPE).toString();
+        for (int i = 0; i < Type.values().length; i++) {
+            if (Type.values()[i].toString().equals(typeAsString)) {
+                Log.i("EspressoShotCustomization", "EspressoShotCustomization(JSONObject) Type." + Type.values()[i].toString());
+                type = Type.values()[i];
+                break;
+            }
+        }
+
+        String prepAsString = espressoShotCustomizationAsJSON.get(JSON_PREP).toString();
+        for (int i = 0; i < Prep.values().length; i++) {
+            if (Prep.values()[i].toString().equals(prepAsString)) {
+                Log.i("EspressoShotCustomization", "EspressoShotCustomization(JSONObject) Prep." + Prep.values()[i].toString());
+                prep = Prep.values()[i];
+                break;
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/FlavorCustomization.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/FlavorCustomization.java
@@ -1,5 +1,7 @@
 package com.jackingaming.mealmaker3000pos.models.menuitems.drinks.customizations;
 
+import android.util.Log;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -23,8 +25,24 @@ public class FlavorCustomization extends Customization {
 
     public FlavorCustomization(JSONObject flavorCustomizationAsJSON) throws JSONException {
         super(flavorCustomizationAsJSON);
-        sauce = (Sauce) flavorCustomizationAsJSON.get(JSON_SAUCE);
-        syrup = (Syrup) flavorCustomizationAsJSON.get(JSON_SYRUP);
+
+        String sauceAsString = flavorCustomizationAsJSON.get(JSON_SAUCE).toString();
+        for (int i = 0; i < Sauce.values().length; i++) {
+            if (Sauce.values()[i].toString().equals(sauceAsString)) {
+                Log.i("FlavorCustomization", "FlavorCustomization(JSONObject) Sauce." + Sauce.values()[i].toString());
+                sauce = Sauce.values()[i];
+                break;
+            }
+        }
+
+        String syrupAsString = flavorCustomizationAsJSON.get(JSON_SYRUP).toString();
+        for (int i = 0; i < Syrup.values().length; i++) {
+            if (Syrup.values()[i].toString().equals(syrupAsString)) {
+                Log.i("FlavorCustomization", "FlavorCustomization(JSONObject) Syrup." + Syrup.values()[i].toString());
+                syrup = Syrup.values()[i];
+                break;
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/MilkCustomization.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/MilkCustomization.java
@@ -1,5 +1,7 @@
 package com.jackingaming.mealmaker3000pos.models.menuitems.drinks.customizations;
 
+import android.util.Log;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -31,9 +33,33 @@ public class MilkCustomization extends Customization {
 
     public MilkCustomization(JSONObject milkCustomizationAsJSON) throws JSONException {
         super(milkCustomizationAsJSON);
-        foam = (Foam) milkCustomizationAsJSON.get(JSON_FOAM);
-        type = (Type) milkCustomizationAsJSON.get(JSON_TYPE);
-        temperature = (Temperature) milkCustomizationAsJSON.get(JSON_TEMPERATURE);
+
+        String foamAsString = milkCustomizationAsJSON.get(JSON_FOAM).toString();
+        for (int i = 0; i < Foam.values().length; i++) {
+            if (Foam.values()[i].toString().equals(foamAsString)) {
+                Log.i("MilkCustomization", "MilkCustomization(JSONObject) Foam." + Foam.values()[i].toString());
+                foam = Foam.values()[i];
+                break;
+            }
+        }
+
+        String typeAsString = milkCustomizationAsJSON.get(JSON_TYPE).toString();
+        for (int i = 0; i < Type.values().length; i++) {
+            if (Type.values()[i].toString().equals(typeAsString)) {
+                Log.i("MilkCustomization", "MilkCustomization(JSONObject) Type." + Type.values()[i].toString());
+                type = Type.values()[i];
+                break;
+            }
+        }
+
+        String temperatureAsString = milkCustomizationAsJSON.get(JSON_TEMPERATURE).toString();
+        for (int i = 0; i < Temperature.values().length; i++) {
+            if (Temperature.values()[i].toString().equals(temperatureAsString)) {
+                Log.i("MilkCustomization", "MilkCustomization(JSONObject) Temperature." + Temperature.values()[i].toString());
+                temperature = Temperature.values()[i];
+                break;
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/SweetenerCustomization.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/SweetenerCustomization.java
@@ -1,5 +1,7 @@
 package com.jackingaming.mealmaker3000pos.models.menuitems.drinks.customizations;
 
+import android.util.Log;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -22,8 +24,24 @@ public class SweetenerCustomization extends Customization {
 
     public SweetenerCustomization(JSONObject sweetenerCustomizationAsJSON) throws JSONException {
         super(sweetenerCustomizationAsJSON);
-        liquid = (Liquid) sweetenerCustomizationAsJSON.get(JSON_LIQUID);
-        packet = (Packet) sweetenerCustomizationAsJSON.get(JSON_PACKET);
+
+        String liquidAsString = sweetenerCustomizationAsJSON.get(JSON_LIQUID).toString();
+        for (int i = 0; i < Liquid.values().length; i++) {
+            if (Liquid.values()[i].toString().equals(liquidAsString)) {
+                Log.i("SweetenerCustomization", "SweetenerCustomization(JSONObject) Liquid." + Liquid.values()[i].toString());
+                liquid = Liquid.values()[i];
+                break;
+            }
+        }
+
+        String packetAsString = sweetenerCustomizationAsJSON.get(JSON_PACKET).toString();
+        for (int i = 0; i < Packet.values().length; i++) {
+            if (Packet.values()[i].toString().equals(packetAsString)) {
+                Log.i("SweetenerCustomization", "SweetenerCustomization(JSONObject) Packet." + Packet.values()[i].toString());
+                packet = Packet.values()[i];
+                break;
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/TeaCustomization.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/TeaCustomization.java
@@ -1,5 +1,7 @@
 package com.jackingaming.mealmaker3000pos.models.menuitems.drinks.customizations;
 
+import android.util.Log;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -18,7 +20,15 @@ public class TeaCustomization extends Customization {
 
     public TeaCustomization(JSONObject teaCustomizationAsJSON) throws JSONException {
         super(teaCustomizationAsJSON);
-        addChai = (AddChai) teaCustomizationAsJSON.get(JSON_ADD_CHAI);
+
+        String addChaiAsString = teaCustomizationAsJSON.get(JSON_ADD_CHAI).toString();
+        for (int i = 0; i < AddChai.values().length; i++) {
+            if (AddChai.values()[i].toString().equals(addChaiAsString)) {
+                Log.i("TeaCustomization", "TeaCustomization(JSONObject) AddChai." + AddChai.values()[i].toString());
+                addChai = AddChai.values()[i];
+                break;
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/ToppingCustomization.java
+++ b/app/src/main/java/com/jackingaming/mealmaker3000pos/models/menuitems/drinks/customizations/ToppingCustomization.java
@@ -1,5 +1,7 @@
 package com.jackingaming.mealmaker3000pos.models.menuitems.drinks.customizations;
 
+import android.util.Log;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -34,11 +36,51 @@ public class ToppingCustomization extends Customization {
 
     public ToppingCustomization(JSONObject toppingCustomizationAsJSON) throws JSONException {
         super(toppingCustomizationAsJSON);
-        coldFoam = (ColdFoam) toppingCustomizationAsJSON.get(JSON_COLD_FOAM);
-        cinnamonPowder = (CinnamonPowder) toppingCustomizationAsJSON.get(JSON_CINNAMON_POWDER);
-        drizzle = (Drizzle) toppingCustomizationAsJSON.get(JSON_DRIZZLE);
-        cinnamonDolceSprinkles = (CinnamonDolceSprinkles) toppingCustomizationAsJSON.get(JSON_CINNAMON_DOLCE_SPRINKLES);
-        whippedCream = (WhippedCream) toppingCustomizationAsJSON.get(JSON_WHIPPED_CREAM);
+
+        String coldFoamAsString = toppingCustomizationAsJSON.get(JSON_COLD_FOAM).toString();
+        for (int i = 0; i < ColdFoam.values().length; i++) {
+            if (ColdFoam.values()[i].toString().equals(coldFoamAsString)) {
+                Log.i("ToppingCustomization", "ToppingCustomization(JSONObject) ColdFoam." + ColdFoam.values()[i].toString());
+                coldFoam = ColdFoam.values()[i];
+                break;
+            }
+        }
+
+        String cinnamonPowderAsString = toppingCustomizationAsJSON.get(JSON_CINNAMON_POWDER).toString();
+        for (int i = 0; i < CinnamonPowder.values().length; i++) {
+            if (CinnamonPowder.values()[i].toString().equals(cinnamonPowderAsString)) {
+                Log.i("ToppingCustomization", "ToppingCustomization(JSONObject) CinnamonPowder." + CinnamonPowder.values()[i].toString());
+                cinnamonPowder = CinnamonPowder.values()[i];
+                break;
+            }
+        }
+
+        String drizzleAsString = toppingCustomizationAsJSON.get(JSON_DRIZZLE).toString();
+        for (int i = 0; i < Drizzle.values().length; i++) {
+            if (Drizzle.values()[i].toString().equals(drizzleAsString)) {
+                Log.i("ToppingCustomization", "ToppingCustomization(JSONObject) Drizzle." + Drizzle.values()[i].toString());
+                drizzle = Drizzle.values()[i];
+                break;
+            }
+        }
+
+        String cinnamonDolceSprinklesAsString = toppingCustomizationAsJSON.get(JSON_CINNAMON_DOLCE_SPRINKLES).toString();
+        for (int i = 0; i < CinnamonDolceSprinkles.values().length; i++) {
+            if (CinnamonDolceSprinkles.values()[i].toString().equals(cinnamonDolceSprinklesAsString)) {
+                Log.i("ToppingCustomization", "ToppingCustomization(JSONObject) CinnamonDolceSprinkles." + CinnamonDolceSprinkles.values()[i].toString());
+                cinnamonDolceSprinkles = CinnamonDolceSprinkles.values()[i];
+                break;
+            }
+        }
+
+        String whippedCreamAsString = toppingCustomizationAsJSON.get(JSON_WHIPPED_CREAM).toString();
+        for (int i = 0; i < WhippedCream.values().length; i++) {
+            if (WhippedCream.values()[i].toString().equals(whippedCreamAsString)) {
+                Log.i("ToppingCustomization", "ToppingCustomization(JSONObject) WhippedCream." + WhippedCream.values()[i].toString());
+                whippedCream = WhippedCream.values()[i];
+                break;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Previously, wasn't able to return subclasses of Customization back from JSON.

This version has a MealQueueViewerActivity that displays Customization for MenuItem that are Drink (click listeners are only logging to Logcat).